### PR TITLE
feat: 아카이브 API 3종(Project, Profile, Photo) 구현 및 로컬 환경 테스트 완료 (#7)

### DIFF
--- a/src/main/java/com/comp/comp_web/config/OpenApiConfig.java
+++ b/src/main/java/com/comp/comp_web/config/OpenApiConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement; // 이 import가 추가되어야 합니다!
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,10 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
+        // 1. 모든 API 요청에 적용할 보안 요구사항 정의
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList(ApiConstants.BEARER_AUTH_SCHEME);
+
         return new OpenAPI()
             .info(new Info()
                 .title(ApiConstants.API_TITLE)
@@ -25,6 +30,7 @@ public class OpenApiConfig {
                 .license(new License()
                     .name(ApiConstants.API_LICENSE_NAME)
                     .url(ApiConstants.API_LICENSE_URL)))
+            .addSecurityItem(securityRequirement) // ⭐ 이 한 줄이 핵심입니다!
             .components(new Components()
                 .addSecuritySchemes(ApiConstants.BEARER_AUTH_SCHEME,
                     new SecurityScheme()

--- a/src/main/java/com/comp/comp_web/domain/archive/controller/ArchivePhotoController.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/controller/ArchivePhotoController.java
@@ -1,0 +1,35 @@
+package com.comp.comp_web.domain.archive.controller;
+
+import com.comp.comp_web.domain.archive.dto.response.ArchivePhotoResponse;
+import com.comp.comp_web.domain.archive.service.ArchivePhotoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Archive API", description = "동아리 아카이브(프로젝트, OB, 활동사진) API")
+@RestController
+@RequestMapping("/archive")
+@RequiredArgsConstructor
+public class ArchivePhotoController {
+
+    private final ArchivePhotoService archivePhotoService;
+
+    @Operation(summary = "기수별 활동 사진 조회", description = "특정 기수의 활동 사진을 조회합니다. 기수를 보내지 않으면 전체 사진을 최신순으로 반환합니다.")
+    @GetMapping("/image") // ⭐️ 명세서 주소대로 매핑!
+    public ResponseEntity<List<ArchivePhotoResponse>> getPhotos(
+        @Parameter(description = "필터링할 기수 (예: 39)", required = false)
+        @RequestParam(value = "generation", required = false) Integer generation) {
+
+        List<ArchivePhotoResponse> response = archivePhotoService.getPhotos(generation);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/controller/ArchiveProfileController.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/controller/ArchiveProfileController.java
@@ -1,0 +1,45 @@
+package com.comp.comp_web.domain.archive.controller;
+
+import com.comp.comp_web.domain.archive.dto.response.ArchiveProfileResponse;
+import com.comp.comp_web.domain.archive.service.ArchiveProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+// 첫 번째 API랑 같은 "Archive API" 태그를 달아두면,
+// Swagger 메뉴판에서 프로젝트 API와 프로필 API가 예쁘게 한 묶음으로 정리되어 보입니다!
+@Tag(name = "Archive API", description = "동아리 아카이브(프로젝트, OB, 활동사진) API")
+@RestController
+@RequestMapping("/archive")
+@RequiredArgsConstructor
+public class ArchiveProfileController {
+
+    private final ArchiveProfileService archiveProfileService;
+
+    @Operation(summary = "OB 선배님 프로필 조회", description = "기수 및 정렬 조건(이름순 등)에 따라 OB 선배님들의 프로필을 반환합니다.")
+    @GetMapping("/profile")
+    public ResponseEntity<List<ArchiveProfileResponse>> getProfiles(
+
+        // 1. 기수 필터링 주문 받기 (?generation=39)
+        @Parameter(description = "필터링할 기수 (예: 39)", required = false)
+        @RequestParam(value = "generation", required = false) Integer generation,
+
+        // 2. 정렬 조건 주문 받기 (?sort=nameAsc)
+        @Parameter(description = "정렬 조건 (예: nameAsc - 이름 오름차순. 안 보내면 기수 내림차순 기본적용)", required = false)
+        @RequestParam(value = "sort", required = false) String sort) {
+
+        // 주방장(Service)에게 손님이 요구한 기수와 정렬 방식을 그대로 전달합니다!
+        List<ArchiveProfileResponse> response = archiveProfileService.getProfiles(generation, sort);
+
+        // 완성된 요리를 200 OK 상태 코드와 함께 서빙합니다.
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/controller/ArchiveProjectController.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/controller/ArchiveProjectController.java
@@ -2,36 +2,34 @@ package com.comp.comp_web.domain.archive.controller;
 
 import com.comp.comp_web.domain.archive.dto.response.ArchiveProjectResponse;
 import com.comp.comp_web.domain.archive.service.ArchiveProjectService;
+// Swagger를 위한 임포트 추가!
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-// @RestController: "스프링아, 얘는 JSON 데이터를 손님에게 반환하는 웨이터야!" 라고 알려줍니다.
+// @Tag: Swagger 문서에서 이 컨트롤러가 어떤 묶음인지 제목을 달아줍니다.
+@Tag(name = "Archive API", description = "동아리 아카이브(프로젝트, OB, 활동사진) API")
 @RestController
-// @RequestMapping: 이 웨이터가 담당하는 기본 구역(URL)을 설정합니다.
 @RequestMapping("/archive")
 @RequiredArgsConstructor
 public class ArchiveProjectController {
 
-    // 웨이터가 주문을 넘길 주방장(Service)을 연결합니다.
     private final ArchiveProjectService archiveProjectService;
 
-    // @GetMapping: 손님이 "GET /archive/projects"로 요청을 보내면 이 메서드가 실행됩니다.
+    // @Operation: 이 특정 API가 무슨 기능을 하는지 자세한 설명을 적습니다.
+    @Operation(summary = "기수별 과거 프로젝트 조회", description = "기수를 입력하면 해당 기수의 프로젝트를, 입력하지 않으면 전체 프로젝트를 최신순으로 반환합니다.")
     @GetMapping("/projects")
     public ResponseEntity<List<ArchiveProjectResponse>> getProjects(
-        // @RequestParam: 주소창에 적힌 "?generation=39" 값을 뽑아옵니다.
-        // required = false로 설정해서, 값을 안 보내도 에러가 나지 않게 합니다.
+        // @Parameter: 주소창으로 받을 값(파라미터)에 대한 설명을 적습니다.
+        @Parameter(description = "필터링할 기수 (예: 39)", required = false)
         @RequestParam(value = "generation", required = false) Integer generation) {
 
-        // 1. 주방장(Service)에게 기수 정보를 주면서 요리를 부탁합니다.
         List<ArchiveProjectResponse> response = archiveProjectService.getProjects(generation);
-
-        // 2. 완성된 요리를 "200 OK" 상태 코드와 함께 손님에게 서빙합니다.
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/comp/comp_web/domain/archive/controller/ArchiveProjectController.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/controller/ArchiveProjectController.java
@@ -1,0 +1,37 @@
+package com.comp.comp_web.domain.archive.controller;
+
+import com.comp.comp_web.domain.archive.dto.response.ArchiveProjectResponse;
+import com.comp.comp_web.domain.archive.service.ArchiveProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+// @RestController: "스프링아, 얘는 JSON 데이터를 손님에게 반환하는 웨이터야!" 라고 알려줍니다.
+@RestController
+// @RequestMapping: 이 웨이터가 담당하는 기본 구역(URL)을 설정합니다.
+@RequestMapping("/archive")
+@RequiredArgsConstructor
+public class ArchiveProjectController {
+
+    // 웨이터가 주문을 넘길 주방장(Service)을 연결합니다.
+    private final ArchiveProjectService archiveProjectService;
+
+    // @GetMapping: 손님이 "GET /archive/projects"로 요청을 보내면 이 메서드가 실행됩니다.
+    @GetMapping("/projects")
+    public ResponseEntity<List<ArchiveProjectResponse>> getProjects(
+        // @RequestParam: 주소창에 적힌 "?generation=39" 값을 뽑아옵니다.
+        // required = false로 설정해서, 값을 안 보내도 에러가 나지 않게 합니다.
+        @RequestParam(value = "generation", required = false) Integer generation) {
+
+        // 1. 주방장(Service)에게 기수 정보를 주면서 요리를 부탁합니다.
+        List<ArchiveProjectResponse> response = archiveProjectService.getProjects(generation);
+
+        // 2. 완성된 요리를 "200 OK" 상태 코드와 함께 손님에게 서빙합니다.
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/dto/response/ArchivePhotoResponse.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/dto/response/ArchivePhotoResponse.java
@@ -1,0 +1,27 @@
+package com.comp.comp_web.domain.archive.dto.response;
+
+import com.comp.comp_web.domain.archive.entity.ArchivePhoto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArchivePhotoResponse {
+
+    private Long imageId; // 명세서대로 imageId로 이름 맞춤!
+    private Integer generation;
+    private String imageUrl;
+    private String title;
+    private String description;
+
+    // 1번 문에서 나온 날것의 식재료를 예쁜 도시락으로 옮겨 담는 기계
+    public static ArchivePhotoResponse from(ArchivePhoto photo) {
+        return ArchivePhotoResponse.builder()
+            .imageId(photo.getId())
+            .generation(photo.getGeneration())
+            .imageUrl(photo.getImageUrl())
+            .title(photo.getTitle())
+            .description(photo.getDescription())
+            .build();
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/dto/response/ArchiveProfileResponse.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/dto/response/ArchiveProfileResponse.java
@@ -1,0 +1,50 @@
+package com.comp.comp_web.domain.archive.dto.response;
+
+import com.comp.comp_web.domain.archive.entity.ArchiveProfile;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArchiveProfileResponse {
+
+    private Long profileId;
+    private String name;
+    private Integer generation;
+    private String company;
+    private String jobTitle;
+    private String profileImageUrl;
+
+    // ⭐️ 명세서의 "contact": { ... } 중괄호 블록을 만들기 위해,
+    // 아래에서 만든 작은 박스(ContactDto)를 통째로 하나의 칸으로 선언합니다!
+    private ContactDto contact;
+
+    // 👇 연락처 정보들만 따로 예쁘게 묶기 위한 '작은 도시락통' 설계도입니다.
+    @Getter
+    @Builder
+    public static class ContactDto {
+        private String email;
+        private String phone;
+        private String linkedinUrl;
+    }
+
+    // 창고에서 꺼낸 날것의 식재료(Profile)를 예쁜 도시락으로 옮겨 담는 기계
+    public static ArchiveProfileResponse from(ArchiveProfile profile) {
+        return ArchiveProfileResponse.builder()
+            .profileId(profile.getId())
+            .name(profile.getName())
+            .generation(profile.getGeneration())
+            .company(profile.getCompany())
+            .jobTitle(profile.getJobTitle())
+            .profileImageUrl(profile.getProfileImageUrl())
+            // ⭐️ 핵심 가공 포인트:
+            // 큰 박스를 조립하는 와중에, 연락처 정보들만 모아서 '작은 박스(ContactDto)'로 먼저 조립한 뒤,
+            // 그 완성된 작은 박스를 큰 박스의 contact 칸에 쏙 집어넣습니다!
+            .contact(ContactDto.builder()
+                .email(profile.getEmail())
+                .phone(profile.getPhone())
+                .linkedinUrl(profile.getLinkedinUrl())
+                .build())
+            .build();
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/dto/response/ArchiveProjectResponse.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/dto/response/ArchiveProjectResponse.java
@@ -1,0 +1,30 @@
+package com.comp.comp_web.domain.archive.dto.response;
+
+import com.comp.comp_web.domain.archive.entity.ArchiveProject;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArchiveProjectResponse {
+
+    // 프론트엔드가 명세서에서 요구했던 항목들입니다.
+    private Long projectId;
+    private Integer generation;
+    private String title;
+    private String description;
+    private String thumbnailUrl;
+    private String githubUrl;
+
+    // ⭐️ 핵심: 창고에서 꺼낸 날것의 식재료(Entity)를 예쁜 도시락(DTO)으로 옮겨 담는 메서드
+    public static ArchiveProjectResponse from(ArchiveProject project) {
+        return ArchiveProjectResponse.builder()
+            .projectId(project.getId())
+            .generation(project.getGeneration())
+            .title(project.getTitle())
+            .description(project.getDescription())
+            .thumbnailUrl(project.getThumbnailUrl())
+            .githubUrl(project.getGithubUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/entity/ArchivePhoto.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/entity/ArchivePhoto.java
@@ -1,0 +1,39 @@
+package com.comp.comp_web.domain.archive.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "archive_photos")
+public class ArchivePhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 명세서의 imageId 역할
+
+    @Column(nullable = false)
+    private Integer generation; // 기수
+
+    @Column(nullable = false, length = 100)
+    private String title; // 사진 제목 (예: "OT")
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl; // 사진 링크
+
+    // ⭐️ 명세서 반영: 사진 설명 추가!
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Builder
+    public ArchivePhoto(Integer generation, String title, String imageUrl, String description) {
+        this.generation = generation;
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/entity/ArchiveProfile.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/entity/ArchiveProfile.java
@@ -1,0 +1,56 @@
+package com.comp.comp_web.domain.archive.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "archive_profiles")
+public class ArchiveProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 고유 번호 (명세서의 profileId 역할)
+
+    @Column(nullable = false)
+    private Integer generation; // 기수
+
+    @Column(nullable = false, length = 50)
+    private String name; // 이름
+
+    @Column(length = 100)
+    private String company; // 소속/직장
+
+    // ⭐️ 명세서 반영: 직무 추가
+    @Column(name = "job_title", length = 100)
+    private String jobTitle;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl; // 프로필 사진
+
+    // ⭐️ 명세서 반영: 연락처 정보들 (DB에는 이렇게 각각의 기둥으로 저장합니다)
+    @Column(length = 100)
+    private String email;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(name = "linkedin_url", length = 500)
+    private String linkedinUrl;
+
+    @Builder
+    public ArchiveProfile(Integer generation, String name, String company, String jobTitle, String profileImageUrl, String email, String phone, String linkedinUrl) {
+        this.generation = generation;
+        this.name = name;
+        this.company = company;
+        this.jobTitle = jobTitle;
+        this.profileImageUrl = profileImageUrl;
+        this.email = email;
+        this.phone = phone;
+        this.linkedinUrl = linkedinUrl;
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/entity/ArchiveProject.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/entity/ArchiveProject.java
@@ -1,0 +1,47 @@
+package com.comp.comp_web.domain.archive.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// @Entity: "스프링아, 이건 DB 테이블이랑 연결될 식재료(엔티티)야!" 라고 알려줍니다.
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "archive_projects") // 실제 DB에 생성될 테이블 이름입니다.
+public class ArchiveProject {
+
+    // @Id: 이 테이블의 고유 번호(주민등록번호) 역할입니다.
+    // @GeneratedValue: 데이터가 들어올 때마다 1, 2, 3... 자동으로 번호를 매겨줍니다.
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // @Column: DB 테이블의 각 칸(기둥)을 의미합니다.
+    @Column(nullable = false)
+    private Integer generation; // 기수 (예: 39)
+
+    @Column(nullable = false, length = 100)
+    private String title; // 프로젝트 이름
+
+    @Column(columnDefinition = "TEXT")
+    private String description; // 어쩌구저쩌꾸 설명글
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl; // 사진 링크
+
+    @Column(name = "github_url", length = 500)
+    private String githubUrl; // 깃허브 링크
+
+    // @Builder: 나중에 이 식재료에 값을 예쁘게 집어넣기 위한 도구입니다.
+    @Builder
+    public ArchiveProject(Integer generation, String title, String description, String thumbnailUrl, String githubUrl) {
+        this.generation = generation;
+        this.title = title;
+        this.description = description;
+        this.thumbnailUrl = thumbnailUrl;
+        this.githubUrl = githubUrl;
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/repository/ArchivePhotoRepository.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/repository/ArchivePhotoRepository.java
@@ -1,0 +1,14 @@
+package com.comp.comp_web.domain.archive.repository;
+
+import com.comp.comp_web.domain.archive.entity.ArchivePhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ArchivePhotoRepository extends JpaRepository<ArchivePhoto, Long> {
+
+    // 1. 특정 기수의 사진 조회 (가장 최근에 올린 사진부터 보여주기 위해 OrderByIdDesc 추가)
+    List<ArchivePhoto> findByGenerationOrderByIdDesc(Integer generation);
+
+    // 2. 전체 사진 조회 (최신 기수 먼저, 그리고 최신 사진 먼저)
+    List<ArchivePhoto> findAllByOrderByGenerationDescIdDesc();
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/repository/ArchiveProfileRepository.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/repository/ArchiveProfileRepository.java
@@ -1,0 +1,15 @@
+package com.comp.comp_web.domain.archive.repository;
+
+import com.comp.comp_web.domain.archive.entity.ArchiveProfile;
+import org.springframework.data.domain.Sort; // ⭐️ Sort 도구를 추가로 가져옵니다!
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ArchiveProfileRepository extends JpaRepository<ArchiveProfile, Long> {
+
+    // 1. 특정 기수를 찾되, 정렬 기준(Sort)은 주방장(Service)이 넘겨주는 대로 따르겠다!
+    List<ArchiveProfile> findByGeneration(Integer generation, Sort sort);
+
+    // 💡 참고: 전체를 조회하면서 정렬하는 findAll(Sort sort) 기능은
+    // JpaRepository 안에 이미 기본적으로 탑재되어 있어서 우리가 여기에 굳이 안 적어도 됩니다!
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/repository/ArchiveProjectRepository.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/repository/ArchiveProjectRepository.java
@@ -1,0 +1,15 @@
+package com.comp.comp_web.domain.archive.repository;
+
+import com.comp.comp_web.domain.archive.entity.ArchiveProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+// JpaRepository<관리할 엔티티, 엔티티의 ID 타입(Long)>을 상속받으면 기본 세팅 끝!
+public interface ArchiveProjectRepository extends JpaRepository<ArchiveProject, Long> {
+
+    // 1. 특정 기수(generation)만 찾아서 최신순 정렬 (예: ?generation=39)
+    List<ArchiveProject> findByGenerationOrderByGenerationDesc(Integer generation);
+
+    // 2. 전체 프로젝트를 최신 기수부터 내림차순 정렬 (기수를 안 보냈을 때)
+    List<ArchiveProject> findAllByOrderByGenerationDesc();
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/service/ArchivePhotoService.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/service/ArchivePhotoService.java
@@ -1,0 +1,36 @@
+package com.comp.comp_web.domain.archive.service;
+
+import com.comp.comp_web.domain.archive.dto.response.ArchivePhotoResponse;
+import com.comp.comp_web.domain.archive.entity.ArchivePhoto;
+import com.comp.comp_web.domain.archive.repository.ArchivePhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArchivePhotoService {
+
+    private final ArchivePhotoRepository archivePhotoRepository;
+
+    public List<ArchivePhotoResponse> getPhotos(Integer generation) {
+
+        List<ArchivePhoto> photos;
+
+        // ⭐️ 명세서 로직 완벽 구현: 기수가 있으면 해당 기수만, 없으면 전체 반환!
+        if (generation != null) {
+            photos = archivePhotoRepository.findByGenerationOrderByIdDesc(generation);
+        } else {
+            photos = archivePhotoRepository.findAllByOrderByGenerationDescIdDesc();
+        }
+
+        // 컨베이어 벨트를 돌려 DTO로 변환
+        return photos.stream()
+            .map(ArchivePhotoResponse::from)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/service/ArchiveProfileService.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/service/ArchiveProfileService.java
@@ -1,0 +1,54 @@
+package com.comp.comp_web.domain.archive.service;
+
+import com.comp.comp_web.domain.archive.dto.response.ArchiveProfileResponse;
+import com.comp.comp_web.domain.archive.entity.ArchiveProfile;
+import com.comp.comp_web.domain.archive.repository.ArchiveProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 데이터 조회만 하니까 속도 향상을 위해 읽기 전용 모드 켬!
+public class ArchiveProfileService {
+
+    private final ArchiveProfileRepository archiveProfileRepository;
+
+    // 웨이터(Controller)가 호출할 메인 요리 버튼
+    public List<ArchiveProfileResponse> getProfiles(Integer generation, String sortType) {
+
+        // 1. 프론트엔드가 보낸 정렬 글자(sortType)를 보고, 로봇이 알아들을 수 있는 Sort 규격표로 변환합니다.
+        Sort sort = createSort(sortType);
+
+        List<ArchiveProfile> profiles;
+
+        // 2. 주문서에 기수(generation)가 적혀있는지 확인하고 창고 로봇에게 지시합니다.
+        if (generation != null) {
+            // 특정 기수만 가져오기 (정렬 기준표 포함)
+            profiles = archiveProfileRepository.findByGeneration(generation, sort);
+        } else {
+            // 전체 다 가져오기 (정렬 기준표 포함, findAll은 JpaRepository가 기본으로 가진 마법의 기능입니다)
+            profiles = archiveProfileRepository.findAll(sort);
+        }
+
+        // 3. 컨베이어 벨트(stream)를 돌려서 날것의 식재료를 예쁜 도시락(DTO)으로 하나씩 옮겨 담아 반환합니다.
+        return profiles.stream()
+            .map(ArchiveProfileResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    // 👇 [헬퍼 메서드] 프론트엔드의 텍스트("nameAsc")를 스프링의 Sort 객체로 바꿔주는 번역기
+    private Sort createSort(String sortType) {
+        // 만약 프론트엔드가 "nameAsc" (이름 오름차순)를 원했다면?
+        if ("nameAsc".equals(sortType)) {
+            return Sort.by(Sort.Direction.ASC, "name");
+        }
+
+        // 그 외의 경우 (아무것도 안 보냈거나 이상한 글자를 보냈을 때) 기본값: 기수 내림차순(최신 기수 먼저)
+        return Sort.by(Sort.Direction.DESC, "generation");
+    }
+}

--- a/src/main/java/com/comp/comp_web/domain/archive/service/ArchiveProjectService.java
+++ b/src/main/java/com/comp/comp_web/domain/archive/service/ArchiveProjectService.java
@@ -1,0 +1,41 @@
+package com.comp.comp_web.domain.archive.service;
+
+import com.comp.comp_web.domain.archive.dto.response.ArchiveProjectResponse;
+import com.comp.comp_web.domain.archive.entity.ArchiveProject;
+import com.comp.comp_web.domain.archive.repository.ArchiveProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+// @Service: "스프링아, 얘는 비즈니스 로직을 담당하는 주방장이야!" 라고 등록합니다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 조회만 하는 기능이므로 '읽기 전용'으로 세팅해서 속도를 높입니다.
+public class ArchiveProjectService {
+
+    // 주방장이 창고 로봇을 호출할 수 있게 연결해 줍니다.
+    private final ArchiveProjectRepository archiveProjectRepository;
+
+    // 웨이터(Controller)가 호출할 요리 시작 버튼(메서드)입니다.
+    public List<ArchiveProjectResponse> getProjects(Integer generation) {
+        List<ArchiveProject> projects;
+
+        // 1. 손님이 주문할 때 특정 기수(generation)를 불렀는지 확인합니다.
+        if (generation != null) {
+            // 특정 기수의 프로젝트만 창고에서 가져옵니다.
+            projects = archiveProjectRepository.findByGenerationOrderByGenerationDesc(generation);
+        } else {
+            // 아무 말 안 했으면 전체 프로젝트를 창고에서 싹 다 가져옵니다.
+            projects = archiveProjectRepository.findAllByOrderByGenerationDesc();
+        }
+
+        // 2. 창고에서 꺼낸 날것의 식재료(Entity)들을 줄 세워서(stream),
+        // 예쁜 도시락(DTO)으로 하나씩 옮겨 담고(map), 다시 하나의 상자로 묶어서(collect) 반환합니다.
+        return projects.stream()
+            .map(ArchiveProjectResponse::from)
+            .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
# 이슈 번호
close #7, #20 

# 주요 변경사항
- 아카이브 활동 사진 조회 API 구현: GET /archive/image

- 아카이브 프로젝트 리스트 조회 API 구현: GET /archive/projects

- 아카이브 OB 프로필 조회 API 구현: GET /archive/profile

- JWT 기반 권한 검증 적용: 모든 아카이브 API에 유효한 Access Token 필요

- Swagger UI JWT 인증 연동: OpenApiConfig 수정을 통해 Swagger 상에서 인증 헤더가 자동으로 전송되도록 전역 보안 요구사항 설정 추가

- DB 스키마 자동 생성 설정: 로컬 개발 환경에서의 테스트를 위한 JPA ddl-auto: update 활용 및 테이블 생성 확인

# 문제 해결 과정 (Troubleshooting)
이번 기능을 구현하며 로컬 환경 세팅 및 인증 과정에서 발생한 문제들을 다음과 같이 해결했습니다.

1. MySQL 포트(3306) 충돌 및 프로세스 제어

    - 도커 컨테이너와 맥북 로컬에 설치된 MySQL이 포트를 동시에 점유하려 하여 접속 에러 발생.

    - 끈질기게 부활하는 로컬 mysqld 좀비 프로세스를 launchctl 및 killall 명령어로 완전히 종료시킨 후 도커 MySQL로 단일화하여 해결.

2. 데이터베이스 테이블 미생성 문제

    - ddl-auto: none 설정으로 인해 DB 접속은 성공했으나 테이블이 없어 500 Error 발생.

    - 로컬 환경의 application.properties 설정을 update로 일시 변경하여 User, archive_photos 등 필수 테이블이 자동 생성되도록 조치함. ( 이후 다시 none으로 돌려놓음 )

3. Swagger UI 인증 헤더 누락 현상 (해결)

    - Swagger 상단 Authorize 설정에도 불구하고 실제 API 요청 시 Authorization 헤더가 전달되지 않는 문제 확인.

    - Swagger 설정(OpenAPI Bean) 상의 보안 스키마 정의를 검토할 예정이며, 우선 터미널(curl)을 통해 직접 토큰을 주입하여 API 정상 동작(200 OK)을 검증함.
    -  해결방법 : OpenApiConfig 설정에 SecurityRequirement가 누락된 것을 발견하여 추가함. 이제 별도의 curl 도구 없이 Swagger UI만으로도 전역 인증 및 API 테스트가 가능하도록 개선함.

# 테스트 결과 (스크린샷)
인증 및 조회 테스트: 터미널에서 Bearer 토큰을 포함한 curl 요청 시 빈 배열([]) 응답 확인 (데이터 부재 상태이나 쿼리 실행 및 인증 성공)
<img width="1340" height="109" alt="스크린샷 2026-03-13 오전 1 07 45" src="https://github.com/user-attachments/assets/1a082dd8-d372-43c3-954f-0ae2b0e8c8e2" />
<img width="1350" height="111" alt="스크린샷 2026-03-13 오전 1 07 16" src="https://github.com/user-attachments/assets/5e6532a7-2bd2-488f-8ea0-f66c1b428adc" />
<img width="1344" height="108" alt="스크린샷 2026-03-13 오전 1 08 15" src="https://github.com/user-attachments/assets/c16b3ad3-2d9d-4aba-9488-6137696d3cc5" />

<img width="929" height="659" alt="스크린샷 2026-03-13 오전 2 01 23" src="https://github.com/user-attachments/assets/c4c444e5-a035-40b9-a974-ed01824214a4" />
<img width="934" height="743" alt="스크린샷 2026-03-13 오전 2 02 07" src="https://github.com/user-attachments/assets/715bd25b-39a7-4269-81a3-bfd273fbef6c" />
<img width="932" height="690" alt="스크린샷 2026-03-13 오전 2 02 22" src="https://github.com/user-attachments/assets/8b0cb904-ae95-421b-89a0-e92f44cea5b8" />

DB 쿼리 로그:

```
Hibernate: select ap1_0.id, ap1_0.description, ap1_0.generation, ap1_0.image_url, ap1_0.title 
from archive_photos ap1_0 
where ap1_0.generation=? 
order by ap1_0.id desc
```

## 참고 및 개선사항
- 현재 Swagger 상에서 토큰이 자동으로 넘어가는 설정을 완료하여, 팀원분들도 상단 Authorize 버튼에 토큰만 넣으시면 바로 테스트가 가능합니다.

- 로컬 테스트 데이터가 없어 []가 반환되므로, 추후 공통 테스트 데이터를 DB에 insert 하여 최종 검수를 진행할 예정입니다.